### PR TITLE
support disabled user-site to allow use within virtualenv

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -62,9 +62,15 @@ const getPythonScriptsDir = (pythonExecPath, packageDir, env = process.env) => {
       });
       child.on("error", reject);
       child.on("close", code => {
-        if (code !== 0)
-          reject(new Error(`Python site module exited with code ${code}.\n${stderr}`));
-        resolve(stdout);
+        switch (code) {
+          case 0: // user site directory is enabled
+          case 1: // user site directory is disabled by user
+          case 2: // uses site directory is disabled by super user or for security reasons
+            resolve(stdout);
+            break;
+          default: // unknown error
+            reject(new Error(`Python site module exited with code ${code}.\n${stderr}`));
+        }
       })
     }).then(stdout => {
       let siteDir = (/^(.*)$/m).exec(stdout)[1];


### PR DESCRIPTION
When `python -m site --user-site` is executed within a virtualenv, it still prints the user site to STDOUT but returns a different status code.

You seem to rightfully want to ignore disabled user site by the environment by removing the environment variable `PYTHONNOUSERSITE`, but virtualenv disables user site by other means (currently unknown to me) - definitely not with the said environment variable. This means that `site` exits with 1 rather than 0 status code.

Does this seem like a proper way to handler this?

This is an attempt to solve puresec/serverless-puresec-cli#12